### PR TITLE
Fix case-insensitive message search

### DIFF
--- a/internal/database/mock_db.go
+++ b/internal/database/mock_db.go
@@ -136,11 +136,13 @@ func matchesQuery(log *models.Log, query *models.LogQuery) bool {
 	return true
 }
 
-// contains checks if a string contains a substring (case-sensitive)
+// contains checks if a string contains a substring (case-insensitive)
+// This better matches the behaviour of the MongoDB implementation,
+// which uses a case-insensitive regex when filtering by message.
 func contains(s, substr string) bool {
 	if substr == "" {
 		return true // Empty substring is always contained
 	}
 
-	return strings.Contains(s, substr)
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }

--- a/internal/database/mock_db_test.go
+++ b/internal/database/mock_db_test.go
@@ -201,6 +201,7 @@ func TestContains(t *testing.T) {
 		expected bool
 	}{
 		{"Failed to connect to DB", "Failed", true},
+		{"Failed to connect to DB", "failed", true},
 		{"User authentication successful", "Failed", false},
 		{"Failed", "Failed", true},
 		{"", "Failed", false},


### PR DESCRIPTION
## Summary
- make MockDB's message search case-insensitive
- test the new behavior

## Testing
- `go test ./...` *(fails: missing go.sum)*

------
https://chatgpt.com/codex/tasks/task_e_687c05f646dc832983874f8bc44dcd72